### PR TITLE
ensure example-test is runnable + responseErr is ptr

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -41,6 +41,7 @@ func ExampleImport() {
 		fmt.Printf("We've got an MP4 file at the bare minimum\n")
 	}
 
+	// Output:
 	// We've got a page alright
 	// We've got an embed page alright
 	// We've got files

--- a/gifs.go
+++ b/gifs.go
@@ -137,7 +137,10 @@ type responseError struct {
 	Message string `json:"message,omitempty"`
 }
 
-func (re responseError) Error() string {
+func (re *responseError) Error() string {
+	if re == nil {
+		return ""
+	}
 	return re.Message
 }
 


### PR DESCRIPTION
- Ensure example test with output is runnable.
- Also make ResponseError.Error receiver is a pointer
  since its instances are pointers and invoke .Error
  for a non-pointer receiver.
