### PR TITLE
added effects

### DIFF
--- a/effects.go
+++ b/effects.go
@@ -1,0 +1,61 @@
+package gifs
+
+// Effects define the collection of alterations
+// that will be applied to media.
+// Any timed effect's start and end times should
+// be considered relative to time 0 after trimming.
+type Effects struct {
+	Overlay []*Overlay `json:"overlay,omitempty"`
+	Pad     []*Pad     `json:"pad,omitempty"`
+	Flip    []*Flip    `json:"flip,omitempty"`
+	Invert  []*Invert  `json:"invert,omitempty"`
+}
+
+// Timeline defines the duration on a timescale
+// for which an effect will appear on the video.
+type Timeline struct {
+	Start float32 `json:"start,omitempty"`
+	End   float32 `json:"end,omitempty"`
+}
+
+// Section defines a bounding box in which
+// the defined effect will appear.
+type Section struct {
+	X      string  `json:"x,omitempty"`
+	Y      string  `json:"y,omitempty"`
+	Width  float32 `json:"width,omitempty"`
+	Height float32 `json:"height,omitempty"`
+}
+
+// Overlay defines a gif, or static image that will be
+// applied to the final media at a position for a
+// specified time period if defined.
+type Overlay struct {
+	X        string    `json:"x,omitempty"`
+	Y        string    `json:"y,omitempty"`
+	Timeline *Timeline `json:"timeline,omitempty"`
+	Source   string    `json:"source,omitempty"`
+
+	// LoopCount if set defines the number of times
+	// that an animated overlay will loop for.
+	LoopCount int `json:"loop_count,omitempty"`
+}
+
+type Pad struct {
+	X      float32 `json:"x,omitempty"`
+	Y      float32 `json:"y,omitempty"`
+	Color  string  `json:"color,omitempty"`
+	Height float32 `json:"height,omitempty"`
+	Width  float32 `json:"width,omitempty"`
+}
+
+type Flip struct {
+	Horizontal bool `json:"horizontal,omitempty"`
+	Vertical   bool `json:"vertical,omitempty"`
+}
+
+type Invert struct {
+	Enable   bool      `json:"enable,omitempty"`
+	Section  *Section  `json:"section,omitempty"`
+	Timeline *Timeline `json:"timeline,omitempty"`
+}

--- a/example_test.go
+++ b/example_test.go
@@ -57,7 +57,7 @@ func ExampleImport() {
 	}
 
 	// Output:
-	// We've got a page alright.
+	// We've got a page alright
 	// We've got an embed page alright
 	// We've got files
 	// We've got an MP4 file at the bare minimum
@@ -123,4 +123,87 @@ func ExampleImportBySources() {
 	if resLen != srcsLen {
 		log.Fatalf("responsesLength(%d) does not match requestsLength (%d)\n", resLen, srcsLen)
 	}
+}
+
+func ExampleEffects() {
+	g, err := gifs.New()
+	if err != nil {
+		log.Fatalf("failed to initialize a new GIFS client, err=%v\n", err)
+	}
+
+	param := &gifs.Request{
+		URL: "https://www.youtube.com/watch?v=ybMEINc5KRw",
+		Trim: &gifs.Trim{
+			Start: 45.5,
+			End:   55.5,
+		},
+
+		Title: "No Chill - Vic Mensa & Skrillex",
+		Tags:  []string{"vic mensa", "skrillex"},
+
+		CreatedFrom: "gifs-go-tests",
+
+		Effects: &gifs.Effects{
+			Overlay: []*gifs.Overlay{
+				{
+					X: "100", Y: "100",
+					Source: "https://cdn.gifs.com/spinning.gif",
+					Timeline: &gifs.Timeline{
+						Start: 1.2,
+						End:   8.5,
+					},
+				},
+				{
+					X: "0", Y: "0", Source: "https://cdn.gifs.com/thug-life-demo.png",
+				},
+			},
+			Flip: []*gifs.Flip{
+				{Horizontal: true, Vertical: true},
+			},
+			Invert: []*gifs.Invert{
+				{
+					Timeline: &gifs.Timeline{Start: 0.5, End: 9},
+					Section: &gifs.Section{
+						X: "50", Y: "50", Width: 60, Height: 60,
+					},
+				},
+				{
+					Timeline: &gifs.Timeline{Start: 5, End: 10},
+					Section: &gifs.Section{
+						X: "50", Y: "60", Width: 40, Height: 80,
+					},
+				},
+			},
+		},
+
+		Attribution: &gifs.Attribution{
+			SiteName:     "gifs-developers",
+			SiteURL:      "https://github.com/gifs",
+			SiteUsername: "gifs",
+		},
+	}
+
+	res, err := g.Import(param)
+	if err != nil {
+		log.Fatalf("failed to import your media, err=%v\n", err)
+	}
+
+	if res.Page != "" {
+		fmt.Printf("We've got a page alright\n")
+	}
+	if res.Embed != "" {
+		fmt.Printf("We've got an embed page alright\n")
+	}
+	if res.HasFiles() {
+		fmt.Printf("We've got files\n")
+	}
+	if res.File(gifs.MP4) != "" {
+		fmt.Printf("We've got an MP4 file at the bare minimum\n")
+	}
+
+	// Output:
+	// We've got a page alright
+	// We've got an embed page alright
+	// We've got files
+	// We've got an MP4 file at the bare minimum
 }

--- a/gifs.go
+++ b/gifs.go
@@ -134,6 +134,10 @@ type Request struct {
 	// * The value of (y+height) must be less than or equal to the height of the media
 	Crop *Crop `json:"crop,omitempty"`
 
+	// Effects defines alterations that will be applied to the final media
+	// in an area that may be defined by a section or a timeline.
+	Effects *Effects `json:"effects,omitempty"`
+
 	callbackURI string `json:"-"`
 }
 


### PR DESCRIPTION
Added a few effects for more flexibility and extensibility.
Effects introduced include:
+ Flip
+ Pad
+ Overlay
+ Invert

Along with Sections and Timelines which we use to control
bounding of an effect either within a box or a timescale.

An example is provided in `ExampleEffects` and the sample final gif is at
https://gifs.com/gif/76Vgw1
or inlined below:

![76vgw1-2](https://cloud.githubusercontent.com/assets/4898263/21293350/65a774be-c4d6-11e6-9949-e5612ea6766c.gif)

